### PR TITLE
Rollback dependency on lint workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   # https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
   deploy:
-    needs: [markdownlint, markdown-link-check]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
The desired behavior was to only run the deploy workflow when the jobs in the lint workflow completed successfully. I implemented it incorrectly, and as far as I know there is no easy way to implement the desired behavior. See the [`workflow_run` trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) for the closest I could find. In the end it doesn't really matter because the website can still be deployed when linting fails.