### PR TITLE
GitHub Action for Linting Hyperlink Redirection

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,12 +1,7 @@
 name: 'Lint New Tab Links'
 description: 'Check links to external sites redirect to a new tab'
 runs:
-  using: composite
+  using: "composite"
   steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-      run: |
-        python3 lint_links.py
+    - run: python3 lint_links.py
+      shell: bash

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,12 @@
+name: 'Lint New Tab Links'
+description: 'Check links to external sites redirect to a new tab'
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+      run: |
+        python3 lint_links.py

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -3,5 +3,5 @@ description: 'Check links to external sites redirect to a new tab'
 runs:
   using: "composite"
   steps:
-    - run: python3 lint_links.py
+    - run: python3 $GITHUB_ACTION_PATH/lint_links.py
       shell: bash

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -76,9 +76,6 @@ def check_markdown_file(filename, matcher):
             if match is not None:
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
-
-                # Print for GitHub annotations
-                print(f"::error file={filename},line={line_number+1}::{match[0]}", file=sys.stderr)
     
     return passed, error_message_buffer
 

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -76,6 +76,8 @@ def check_markdown_file(filename, matcher):
             if match is not None:
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
+
+                print(f"::error file={filename},line={line_number+1}::{match[0]}", file=sys.stderr)
     
     return passed, error_message_buffer
 

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -104,7 +104,7 @@ def print_check_message(filename, check_passed, check_number, error_message):
 def main():
     root = './docs/'
     markdown_files = get_markdown_files(root)
-    bad_link_matcher = re.compile(r"(?<!!)\[.*\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")
+    bad_link_matcher = re.compile(r"(?<!!)\[.*?\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")
     passed = lint_markdown_files(markdown_files, bad_link_matcher)
     return passed
 

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -8,6 +8,8 @@ FAILED_MSG = '[FAILED]'
 ERROR_MSG1 = 'External links should redirect to a new tab. Change the link to '
 ERROR_MSG2 = "{target=_blank}"
 
+annotations = []
+
 ## HELPER FUNCTIONS
 def get_markdown_files(root_dir):
     """
@@ -78,8 +80,7 @@ def check_markdown_file(filename, matcher):
             if match is not None:
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
-
-                print(f"::error file={filename},line={line_number+1}::{ERROR_MSG1 + match[0] + ERROR_MSG2}", file=sys.stderr)
+                annotations.append(f"::error file={filename},line={line_number+1}::{ERROR_MSG1 + match[0] + ERROR_MSG2}")
     
     return passed, error_message_buffer
 
@@ -110,4 +111,5 @@ def main():
 if __name__ == '__main__':
     passed = main()
     if not passed:
+        print("\n".join(annotations), file=sys.stderr)
         sys.exit(1)

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -1,0 +1,108 @@
+import os
+import re
+
+## CONSTANTS
+PASSED_MSG = '[PASSED]'
+FAILED_MSG = '[FAILED]'
+
+## HELPER FUNCTIONS
+def get_markdown_files(root):
+    """
+    Recursively searches for markdown files (.md) starting at a specified root directory.
+
+    Args:
+        root (str): The root directory to start the search at.
+
+    Returns:
+        List[str]: A list of markdown file paths relative to the root directory.
+    """
+    markdown_files = []
+    markdown_matcher = re.compile(r".+\.md")
+    for root, dirs, files in os.walk(root):
+        markdown_file_basenames = filter(lambda f: markdown_matcher.match(f) is not None, files)
+        markdown_files_with_full_path = map(lambda f: os.path.join(root, f), markdown_file_basenames)
+        markdown_files += list(markdown_files_with_full_path)
+    return markdown_files
+
+
+def lint_markdown_files(files, matcher):
+    """
+    Lints all specified markdown files and checks for any links to outside the Sailbot Docs website 
+    that do not redirect to a new tab. If any such links exists, the linting process fails.
+
+    Args:
+        files (List[str]): A list of markdown file paths relative to some root directory.
+        matcher (re.Pattern): A compiled regular expression object used to perform the linting.
+
+    Returns:
+        bool: Returns True if the linting process succeeds for all markdown files and False otherwise.
+    """
+    passed = True
+    num_passed = 0
+    num_checks = len(files)
+
+    for n, file in enumerate(files):
+        check_passed, error_message = check_markdown_file(file, matcher)
+        passed = (passed and check_passed)
+        num_passed += int(check_passed)
+        print_check_message(file, check_passed, n+1, error_message)
+
+    print(f"{num_passed}/{num_checks} checks passed")
+
+    return passed
+
+
+def check_markdown_file(filename, matcher):
+    """
+    Lints a specified markdown file.
+
+    Args:
+        filename (str): The path to the markdown file relative to some root directory.
+        matcher (re.Pattern): A compiled regular expression object used to perform the linting.
+
+    Returns:
+        tuple[bool, str]: Returns a tuple containing two variables:
+            1. A boolean variable that indicates if the check passes
+            2. A string containing an error message. This string is empty if the check passes.
+    """
+    passed = True
+    error_message_buffer = ""
+
+    with open(filename) as file:
+        for line_number, line_text in enumerate(file.readlines()):
+            match = matcher.match(line_text)
+
+            if match is not None:
+                passed = False
+                error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
+    
+    return passed, error_message_buffer
+
+
+def print_check_message(filename, check_passed, check_number, error_message):
+    """
+    Prints the status of a markdown file after a check. Any errors will be printed along with
+    the status.
+
+    Args:
+        filename (str): The path to the markdown file relative to some root directory.
+        check_passed (bool): Whether the check on the markdown file passed or not.
+        check_number (int): The check number.
+        error_message (str): An error message (empty if the check passed).
+    """
+    status = PASSED_MSG if check_passed else FAILED_MSG
+    print(f"Check {check_number}: {status} {filename}")
+    print(error_message)
+
+
+## MAIN LOGIC
+def main():
+    os.chdir('../../../docs/')
+    root = '.'
+    markdown_files = get_markdown_files(root)
+    bad_link_matcher = re.compile(r"(?<!!)\[.*\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")
+    passed = lint_markdown_files(markdown_files, bad_link_matcher)
+    assert passed
+
+if __name__ == '__main__':
+    main()

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -98,8 +98,7 @@ def print_check_message(filename, check_passed, check_number, error_message):
 
 ## MAIN LOGIC
 def main():
-    os.chdir('docs/')
-    root = '.'
+    root = './docs/'
     markdown_files = get_markdown_files(root)
     bad_link_matcher = re.compile(r"(?<!!)\[.*\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")
     passed = lint_markdown_files(markdown_files, bad_link_matcher)

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -77,7 +77,8 @@ def check_markdown_file(filename, matcher):
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
 
-                print(f"::error file={filename},line={line_number+1}::{match[0]}")
+                # Print for GitHub annotations
+                print(f"::error file={filename},line={line_number+1}::{match[0]}", file=sys.stderr)
     
     return passed, error_message_buffer
 
@@ -94,8 +95,8 @@ def print_check_message(filename, check_passed, check_number, error_message):
         error_message (str): An error message (empty if the check passed).
     """
     status = PASSED_MSG if check_passed else FAILED_MSG
-    print(f"Check {check_number}: {status} {filename}")
-    print(error_message)
+    outfile = sys.stdout if check_passed else sys.stderr
+    print(f"Check {check_number}: {status} {filename}\n" + error_message, file=outfile)
 
 
 ## MAIN LOGIC

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import re
 
 ## CONSTANTS
@@ -102,7 +103,9 @@ def main():
     markdown_files = get_markdown_files(root)
     bad_link_matcher = re.compile(r"(?<!!)\[.*\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")
     passed = lint_markdown_files(markdown_files, bad_link_matcher)
-    assert passed
+    return passed
 
 if __name__ == '__main__':
-    main()
+    passed = main()
+    if not passed:
+        sys.exit(1)

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -7,19 +7,19 @@ PASSED_MSG = '[PASSED]'
 FAILED_MSG = '[FAILED]'
 
 ## HELPER FUNCTIONS
-def get_markdown_files(root):
+def get_markdown_files(root_dir):
     """
     Recursively searches for markdown files (.md) starting at a specified root directory.
 
     Args:
-        root (str): The root directory to start the search at.
+        root_dir (str): The root directory to start the search at.
 
     Returns:
         List[str]: A list of markdown file paths relative to the root directory.
     """
     markdown_files = []
     markdown_matcher = re.compile(r".+\.md")
-    for root, dirs, files in os.walk(root):
+    for root, dirs, files in os.walk(root_dir):
         markdown_file_basenames = filter(lambda f: markdown_matcher.match(f) is not None, files)
         markdown_files_with_full_path = map(lambda f: os.path.join(root, f), markdown_file_basenames)
         markdown_files += list(markdown_files_with_full_path)

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -94,8 +94,7 @@ def print_check_message(filename, check_passed, check_number, error_message):
         error_message (str): An error message (empty if the check passed).
     """
     status = PASSED_MSG if check_passed else FAILED_MSG
-    outfile = sys.stdout if check_passed else sys.stderr
-    print(f"Check {check_number}: {status} {filename}\n" + error_message, file=outfile)
+    print(f"Check {check_number}: {status} {filename}\n" + error_message)
 
 
 ## MAIN LOGIC

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -22,7 +22,7 @@ def main():
     # Perform the linting process
     markdown_files = get_markdown_files(ROOT)
     passed = lint_markdown_files(markdown_files, REGEX_PATTERN)
-    
+
     # If linting fails, print any annotations to stderr for GitHub and exit with status code 1
     if not passed:
         print("\n".join(annotations), file=sys.stderr)
@@ -91,7 +91,7 @@ def check_markdown_file(filename, pattern):
     """
     passed = True
     error_message_buffer = ""
-    
+
     with open(filename) as file:
         for line_number, line_text in enumerate(file.readlines()):
             match = re.findall(pattern, line_text, flags=re.M)
@@ -120,4 +120,3 @@ def print_check_message(filename, check_passed, check_number, error_message):
 
 if __name__ == '__main__':
     main()
-    

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -5,6 +5,8 @@ import re
 ## CONSTANTS
 PASSED_MSG = '[PASSED]'
 FAILED_MSG = '[FAILED]'
+ERROR_MSG1 = 'External links should redirect to a new tab. Change the link to '
+ERROR_MSG2 = "{target=_blank}"
 
 ## HELPER FUNCTIONS
 def get_markdown_files(root_dir):
@@ -77,7 +79,7 @@ def check_markdown_file(filename, matcher):
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
 
-                print(f"::error file={filename},line={line_number+1}::{match[0]}", file=sys.stderr)
+                print(f"::error file={filename},line={line_number+1}::{ERROR_MSG1 + match[0] + ERROR_MSG2}", file=sys.stderr)
     
     return passed, error_message_buffer
 

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -1,15 +1,33 @@
+## IMPORTS
 import os
 import sys
 import re
 
+
 ## CONSTANTS
 REGEX_PATTERN = r"(?<!!)\[.*?\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})"
-PASSED_MSG = '[PASSED]'
-FAILED_MSG = '[FAILED]'
-ERROR_MSG1 = 'External links should redirect to a new tab. Change the link to '
+ROOT = "./docs/"
+PASSED_MSG = "[PASSED]"
+FAILED_MSG = "[FAILED]"
+ERROR_MSG1 = "External links should redirect to a new tab. Change the link to "
 ERROR_MSG2 = "{target=_blank}"
 
+# Annotation strings for GitHub error annotations
 annotations = []
+
+
+## MAIN LOGIC
+def main():
+
+    # Perform the linting process
+    markdown_files = get_markdown_files(ROOT)
+    passed = lint_markdown_files(markdown_files, REGEX_PATTERN)
+    
+    # If linting fails, print any annotations to stderr for GitHub and exit with status code 1
+    if not passed:
+        print("\n".join(annotations), file=sys.stderr)
+        sys.exit(1)
+
 
 ## HELPER FUNCTIONS
 def get_markdown_files(root_dir):
@@ -73,17 +91,15 @@ def check_markdown_file(filename, pattern):
     """
     passed = True
     error_message_buffer = ""
-
+    
     with open(filename) as file:
         for line_number, line_text in enumerate(file.readlines()):
             match = re.findall(pattern, line_text, flags=re.M)
-
             if match:
                 passed = False
                 for link in match:
                     error_message_buffer += f"\tLine {line_number+1}: {link}\n"
                     annotations.append(f"::error file={filename},line={line_number+1}::{ERROR_MSG1 + link + ERROR_MSG2}")
-    
     return passed, error_message_buffer
 
 
@@ -102,15 +118,6 @@ def print_check_message(filename, check_passed, check_number, error_message):
     print(f"Check {check_number}: {status} {filename}\n" + error_message)
 
 
-## MAIN LOGIC
-def main():
-    root = './docs/'
-    markdown_files = get_markdown_files(root)
-    passed = lint_markdown_files(markdown_files, REGEX_PATTERN)
-    return passed
-
 if __name__ == '__main__':
-    passed = main()
-    if not passed:
-        print("\n".join(annotations), file=sys.stderr)
-        sys.exit(1)
+    main()
+    

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -77,7 +77,7 @@ def check_markdown_file(filename, matcher):
                 passed = False
                 error_message_buffer += f"\tLine {line_number+1}: {match[0]}\n"
 
-                print(f"::error file={filename},line={line_number+1}::{match[0]}", file=sys.stderr)
+                print(f"::error file={filename},line={line_number+1}::{match[0]}")
     
     return passed, error_message_buffer
 

--- a/.github/actions/lint/lint_links.py
+++ b/.github/actions/lint/lint_links.py
@@ -97,7 +97,7 @@ def print_check_message(filename, check_passed, check_number, error_message):
 
 ## MAIN LOGIC
 def main():
-    os.chdir('../../../docs/')
+    os.chdir('docs/')
     root = '.'
     markdown_files = get_markdown_files(root)
     bad_link_matcher = re.compile(r"(?<!!)\[.*\]\(\s*https?:\/\/[^\(\)]+\)(?!\{\s*:?\s*target\s*=\s*(?:\s*_blank\s*|\s*\"\s*_blank\s*\"\s*)\})")

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - user/dfriend01/70-hyperlinks-action
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,3 +34,6 @@ jobs:
         config-file: '.markdown-link-check.json'
         folder-path: 'docs'
         file-path: './README.md'
+
+    - name: Check links to external sites redirect to a new tab
+      uses: ./.github/actions/lint/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - user/dfriend01/70-hyperlinks-action
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,5 +36,11 @@ jobs:
         folder-path: 'docs'
         file-path: './README.md'
 
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
     - name: Check links to external sites redirect to a new tab
       uses: ./.github/actions/lint/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,11 +36,19 @@ jobs:
         folder-path: 'docs'
         file-path: './README.md'
 
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+  markdown-link-redirection-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Check links to external sites redirect to a new tab
-      uses: ./.github/actions/lint/
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Check links to external sites redirect to a new tab
+        uses: ./.github/actions/lint/
+
+     

--- a/docs/reference/cpp/differences.md
+++ b/docs/reference/cpp/differences.md
@@ -181,12 +181,12 @@ wherever they're used. For example:
     ```
 
 !!! note
-    `AREA_OF_CIRCLE` is a macro with arguments. If you are confused by it, [this resource](https://www.cs.yale.edu/homes/aspnes/pinewiki/C(2f)Macros.html)
+    `AREA_OF_CIRCLE` is a macro with arguments. If you are confused by it, [this resource](https://www.cs.yale.edu/homes/aspnes/pinewiki/C(2f)Macros.html){target=_blank}
     has a detailed explanation on how they work.
 
-Because of this copy-pasting, you need to be very careful with syntax, sometimes necessitating an ugly [`do {} while(0)`
-wrapper](https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block). Moreover, symbols
-declared with `#define` are always globally visible, ignoring namespaces!
+Because of this copy-pasting, you need to be very careful with syntax, sometimes necessitating an ugly
+[`do {} while(0)` wrapper](https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block){target=_blank}.
+Moreover, symbols declared with `#define` are always globally visible, ignoring namespaces!
 
 In C++, the use of constant expressions are preferred.
 
@@ -216,14 +216,14 @@ void bar (void) {
 
 Lambdas are primarily useful when you need to register a callback function one time and don't feel it's necessary to
 write out a full function. They are in no way required though, so do not worry about learning them. However, it's
-necessary to know that they exist such that you don't get confused when reading code. For more information, [go here](https://learn.microsoft.com/en-us/cpp/cpp/lambda-expressions-in-cpp?view=msvc-170)
+necessary to know that they exist such that you don't get confused when reading code. For more information, [go here](https://learn.microsoft.com/en-us/cpp/cpp/lambda-expressions-in-cpp?view=msvc-170){target=_blank}
 for Microsoft's explanation.
 
 ## Misc
 
 ### Arrays
 
-Using the [C++ implementation of arrays](https://en.cppreference.com/w/cpp/container/array#:~:text=std%3A%3Aarray%20is%\20a%20container%20that%20encapsulates%20fixed%20size,C-style%20array%2C%20it%20doesn%27t%20decay%20to%20T%2A%20automatically.)
+Using the [C++ implementation of arrays](https://en.cppreference.com/w/cpp/container/array#:~:text=std%3A%3Aarray%20is%\20a%20container%20that%20encapsulates%20fixed%20size,C-style%20array%2C%20it%20doesn%27t%20decay%20to%20T%2A%20automatically.){target=_blank}
 is preferred over C arrays. It is simply easier and safer to work with than a standard C array without any performance
 costs.
 

--- a/docs/reference/cpp/index.md
+++ b/docs/reference/cpp/index.md
@@ -24,8 +24,8 @@ syntax and the mechanisms of the language.
 
 | Resource               | Description                                                                                 |
 | :--------------------- | :------------------------------------------------------------------------------------------ |
-| [w3schools Tutorial](https://www.w3schools.com/cpp/default.asp) | A structured tutorial that goes through basic concepts in C++. It's good to do up to the section on Classes. |
-| [YouTube Tutorial](https://youtu.be/vLnPwxZdW4Y) | If you prefer video tutorial, then this is a comprehensive 4 hour video covering similar concepts to the one above. It is 4 hours long though. |
-| [Dynamic Memory Overview](https://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm) | A page going over how dynamic memory works in C++. |
+| [w3schools Tutorial](https://www.w3schools.com/cpp/default.asp){target=_blank} | A structured tutorial that goes through basic concepts in C++. It's good to do up to the section on Classes. |
+| [YouTube Tutorial](https://youtu.be/vLnPwxZdW4Y){target=_blank} | If you prefer video tutorial, then this is a comprehensive 4 hour video covering similar concepts to the one above. It is 4 hours long though. |
+| [Dynamic Memory Overview](https://www.tutorialspoint.com/cplusplus/cpp_dynamic_memory.htm){target=_blank} | A page going over how dynamic memory works in C++. |
 
 Feel free to add other resources other than the ones listed above if you find any that you like!

--- a/docs/reference/cpp/tools.md
+++ b/docs/reference/cpp/tools.md
@@ -5,13 +5,14 @@ A lot goes into making a well structured C++ project, much more than any one tea
 ## CMake
 
 CMake is a powerfull build automation tool that makes compiling code for large projects with a lot of interoperating
-files a lot easier. Steps 1-3 of the [official tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)
+files a lot easier. Steps 1-3 of the [official tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html){target=_blank}
 are great for understanding the basics.
 
 ## GDB
 
-The [GNU Project Debugger](https://www.sourceware.org/gdb/) is the most commonly debugger for the C language family.
-VSCode also has a degree of integration with GDB that allows an easy to use GUI. This [GDB cheat sheet](https://darkdust.net/files/GDB%20Cheat%20Sheet.pdf)
+The [GNU Project Debugger](https://www.sourceware.org/gdb/){target=_blank} is the most commonly debugger for the C
+language family.
+VSCode also has a degree of integration with GDB that allows an easy to use GUI. This [GDB cheat sheet](https://darkdust.net/files/GDB%20Cheat%20Sheet.pdf){target=_blank}
 has all the GDB comands you will need to know. Be aware the VSCode has GUI buttons for some of these commands that are
 easier to use.
 
@@ -19,8 +20,8 @@ easier to use.
 
 ## GoogleTest
 
-[GoogleTest](https://github.com/google/googletest) is the C++ unit testing framework we will be using.
-The [GoogleTest Primer](https://google.github.io/googletest/primer.html) is a good place to start.
+[GoogleTest](https://github.com/google/googletest){target=_blank} is the C++ unit testing framework we will be using.
+The [GoogleTest Primer](https://google.github.io/googletest/primer.html){target=_blank} is a good place to start.
 
 ??? example
 
@@ -89,27 +90,28 @@ The [GoogleTest Primer](https://google.github.io/googletest/primer.html) is a go
 
 ## Google Protocol Buffer
 
-[Google Protocol Buffer](https://developers.google.com/protocol-buffers) (Protobuf) is a portable data serialization
+[Google Protocol Buffer](https://developers.google.com/protocol-buffers){target=_blank} (Protobuf) is a portable data serialization
 method. We use it over other methods like JSON and XML because it produces smaller binaries, an important consideration
 when sending data across an ocean. Unfortunately, there does not seem to be a easy to follow tutorial for using them,
-but here are the [C++ basics](https://developers.google.com/protocol-buffers/docs/cpptutorial). The page is quite dense
-and can be hard to follow, so do not worry if you do not understand it.
+but here are the [C++ basics](https://developers.google.com/protocol-buffers/docs/cpptutorial){target=_blank}. The page
+is quite dense and can be hard to follow, so do not worry if you do not understand it.
 
 ## Clang
 
-In its most basic form, [Clang](https://clang.llvm.org/) is a compiler for the C language family. Clang has multiple
+In its most basic form, [Clang](https://clang.llvm.org/){target=_blank} is a compiler for the C language family.
+Clang has multiple
 benefits like easier portability compared to, for example, GCC. Clang is actually "half" the compiler, the other half
 being LLVM. Without going into unnecessary detail, Clang compiles C++ code to a generic language before LLVM compiles
 it to machine specific language.
 
 ### Clangd
 
-[Clangd](https://clangd.llvm.org/) is the Clang language server. It provides a much more powerful intellisense than the
-default one used in VSCode's C/C++ extension.
+[Clangd](https://clangd.llvm.org/){target=_blank} is the Clang language server. It provides a much more powerful
+intellisense than the default one used in VSCode's C/C++ extension.
 
 ### Clang-Tidy
 
-[Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/) is a linting tool, who's main purpose is to catch potential
+[Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/){target=_blank} is a linting tool, who's main purpose is to catch potential
 programming errors caused by bad programming style/practices using just static analysis.
 
 ### Clang Format
@@ -119,6 +121,7 @@ as you hit save.
 
 ## llvm-cov
 
-We will use [llvm-cov](https://llvm.org/docs/CommandGuide/llvm-cov.html) to evaluate our test coverage. When used with
-[genhtml](https://www.systutorials.com/docs/linux/man/1-genhtml/), we can generate HTML reports that that show our line,
-function, and branch coverage line-by-line.
+We will use [llvm-cov](https://llvm.org/docs/CommandGuide/llvm-cov.html){target=_blank} to evaluate our test coverage.
+When used with
+[genhtml](https://www.systutorials.com/docs/linux/man/1-genhtml/){target=_blank}, we can generate HTML reports that that
+show our line, function, and branch coverage line-by-line.

--- a/docs/reference/github/workflow/branches.md
+++ b/docs/reference/github/workflow/branches.md
@@ -3,7 +3,7 @@
 We use branching to work on issues without modifying the main line. This ensures that the main line only
 contains functional code and handles merge conflicts that arise
 when multiple people are developing at the same time. For a quick rundown on branching in git,
-consult the official [git documentation](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell).
+consult the official [git documentation](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell){target=_blank}.
 
 ## Creating a branch
 
@@ -120,9 +120,9 @@ Upon inspecting `bar.txt`, we see the following:
 
 Resolving merge conflicts is not always a trivial task, but there are many ways to resolve them which include:
 
-- [Resolving on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github)
+- [Resolving on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github){target=_blank}
 (recommended)
-- [Resolving in Command Line](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)
+- [Resolving in Command Line](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line){target=_blank}
 
 !!! tip
 

--- a/docs/reference/github/workflow/index.md
+++ b/docs/reference/github/workflow/index.md
@@ -25,9 +25,9 @@ you know git. If you are unfamiliar with git, here are a few resources to help y
 
 | Resource                                               | Description                                            |
 | :----------------------------------------------------- | :----------------------------------------------------- |
-| [Beginners Tutorial](https://youtu.be/HVsySz-h9r4)     | A 30 minute video on git for beginners. Good if you want to learn git quickly and nail all the fundamentals.    |
-| [Pro Git book](https://git-scm.com/book/en/v2)         | A textbook on using git. Good if you are a completionist and want to deep dive into how git works (and if you have some time on your hands).    |
-| [Common Git Commands](https://patrick-5546.github.io/notes/reference/git/git_commands/) | A condensed summary of some common git commands. Good to refer to once you are familiar with the fundamentals of git. |
+| [Beginners Tutorial](https://youtu.be/HVsySz-h9r4){target=_blank}     | A 30 minute video on git for beginners. Good if you want to learn git quickly and nail all the fundamentals.    |
+| [Pro Git book](https://git-scm.com/book/en/v2){target=_blank}         | A textbook on using git. Good if you are a completionist and want to deep dive into how git works (and if you have some time on your hands).    |
+| [Common Git Commands](https://patrick-5546.github.io/notes/reference/git/git_commands/){target=_blank} | A condensed summary of some common git commands. Good to refer to once you are familiar with the fundamentals of git. |
 
 ## Remote server: GitHub
 

--- a/docs/reference/github/workflow/issues.md
+++ b/docs/reference/github/workflow/issues.md
@@ -23,7 +23,7 @@ introduced to give us a quick and structured way to writing issues.
 !!! note
 
     GitHub issues are written using GitHub-flavoured markdown. To add a little spice to your issues, refer
-    to the official [GitHub documentation](https://docs.github.com/en/get-started/writing-on-github) 
+    to the official [GitHub documentation](https://docs.github.com/en/get-started/writing-on-github){target=_blank} 
     for some quick tips and tricks on how to write awesome markdown!
 
 Click on the `Get started` button to open the issue template. For this example, let's go with the `New Feature`
@@ -35,7 +35,7 @@ At this point, you should give a succinct title and describe the issue in the te
 sections to fill out. Try to give only the necessary details to make a clear and concise issue. If you are unsure on how
 to construct your issue, take a look at current or past issues and ask the software leads for further guidance if necessary.
 
-Finally, feel free to [make suggestions](https://github.com/UBCSailbot/.github/issues/templates/edit)
+Finally, feel free to [make suggestions](https://github.com/UBCSailbot/.github/issues/templates/edit){target=_blank}
 on new templates or changing current templates!
 
 !!! tip

--- a/docs/reference/github/workflow/pr.md
+++ b/docs/reference/github/workflow/pr.md
@@ -29,7 +29,7 @@ reviewers until you are ready):
 
 Notice how this is remarkably similar to the page of an issue. To link a pull request to an issue, simply add
 `<KEYWORD> #<ISSUE NUMBER>` to the initial comment in the pull request. A list of valid keywords can be found
-[here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+[here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue){target=_blank}.
 
 !!! example
 

--- a/docs/reference/markdown.md
+++ b/docs/reference/markdown.md
@@ -2,8 +2,8 @@
 
 Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents.[^1]
 You can do anything with Markdown, from creating websites to PDF documents, all in a clean format that is easy to
-learn. [Many of your favorite services use Markdown](https://www.markdownguide.org/tools/), so it would be useful
-to pick it up to write technical documentation.
+learn. [Many of your favorite services use Markdown](https://www.markdownguide.org/tools/){target=_blank}, so it would
+be useful to pick it up to write technical documentation.
 
 Markdown is not standardized across services. Many services that support Markdown have their
 own "flavour" of Markdown. Be sure to know the Markdown features of the service
@@ -11,9 +11,9 @@ you are using so that your Markdown renders properly.
 
 ## Getting Started
 
-We recommend [markdownguide.org](https://www.markdownguide.org/) to be your first point of reference if you are learning
-Markdown for the first time. It covers topics like what Markdown is, its syntax, advanced tips, and the different
-services that support Markdown. Flavours of Markdown specific to a service build on top of these basics.
+We recommend [markdownguide.org](https://www.markdownguide.org/){target=_blank} to be your first point of reference if\
+you are learning Markdown for the first time. It covers topics like what Markdown is, its syntax, advanced tips, and the
+different services that support Markdown. Flavours of Markdown specific to a service build on top of these basics.
 
 ## Sailbot and Markdown
 
@@ -45,8 +45,8 @@ different depending on where you are writing, but there usually exists a preview
 !!! note "GitHub-Flavoured Markdown"
 
     GitHub uses its own "flavour" of Markdown. Certain features, like using HTML, are excluded for security reasons.
-    Visit the [official GitHub Markdown guide](https://docs.github.com/en/get-started/writing-on-github) for more
-    information on the available features.
+    Visit the [official GitHub Markdown guide](https://docs.github.com/en/get-started/writing-on-github){target=_blank}
+    for more information on the available features.
 
 ### Material for MkDocs
 
@@ -55,15 +55,15 @@ experience is required to contribute to our docs.
 
 Material for MkDocs supports powerful features purpose-built to take technical documentation to the next level.
 Feel free to browse this site to see how we use these features, exploring their syntax in the
-[source code](https://github.com/UBCSailbot/docs/tree/main/docs). Since GitHub renders Markdown files automatically
+[source code](https://github.com/UBCSailbot/docs/tree/main/docs){target=_blank}. Since GitHub renders Markdown files automatically
 you will need to click the "Raw" button to view their contents.
 
 !!! note "Material-Flavoured Markdown"
 
     Material for MkDocs' flavour of Markdown extends upon vanilla Markdown, adding features such as admonitions 
     (like this note) and content tabs. Refer to the
-    [official Material for MkDocs reference page](https://squidfunk.github.io/mkdocs-material/reference/) for more
-    information on the available features.
+    [official Material for MkDocs reference page](https://squidfunk.github.io/mkdocs-material/reference/){target=_blank}
+    for more information on the available features.
 
 ## Rendering Markdown
 
@@ -73,20 +73,21 @@ need to consult the documentation from the service provider to render their flav
 resources are good for rendering Markdown:
 
 === ":simple-markdown: Vanilla"
-    - [VS Code](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview): Markdown rendering is supported
+    - [VS Code](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview){target=_blank}: Markdown
+    rendering is supported
     out of the box.
-    - [Markdown Live Preview](https://markdownlivepreview.com/): An online rendering tool.
+    - [Markdown Live Preview](https://markdownlivepreview.com/){target=_blank}: An online rendering tool.
 
 === ":simple-github: Github"
-    - [Markdown Preview GitHub Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles):
+    - [Markdown Preview GitHub Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles){target=_blank}:
     VS Code extension that renders GitHub-flavoured markdown.
     - Create a draft issue on GitHub and preview the markdown to see how it renders.
 
 === ":logo: Material for MkDocs"
     - UBC Sailbot Docs: To preview your changes when working on this site,
-    refer to the [run instructions in the `README.md`](https://github.com/UBCSailbot/docs#run).
+    refer to the [run instructions in the `README.md`](https://github.com/UBCSailbot/docs#run){target=_blank}.
     - Material for MkDocs sites in general: If you ever decide to write your own documentation using Material for MkDocs,
-    refer to the [official "Getting Started" guide](https://squidfunk.github.io/mkdocs-material/getting-started/).
+    refer to the [official "Getting Started" guide](https://squidfunk.github.io/mkdocs-material/getting-started/){target=_blank}.
 
 Other resources exist to render Markdown like browser extensions that render Markdown as HTML and GitHub repositories
 that contain source code to render your Markdown. Feel free
@@ -96,11 +97,11 @@ to browse around for the solution that suits your needs.
 
 We lint our Markdown files to reduce errors and increase readability. In particular, we use two tools:
 
-1. [markdownlint](https://github.com/DavidAnson/markdownlint) is
-used to enforce a style guide. Its configuration file for this repository is [`.markdownlint.json`](https://github.com/UBCSailbot/docs/blob/main/.markdownlint.json).
-If you use VS Code, there is a [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).
+1. [markdownlint](https://github.com/DavidAnson/markdownlint){target=_blank} is
+used to enforce a style guide. Its configuration file for this repository is [`.markdownlint.json`](https://github.com/UBCSailbot/docs/blob/main/.markdownlint.json){target=_blank}.
+If you use VS Code, there is a [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint){target=_blank}.
 
-2. [markdown-link-check](https://github.com/tcort/markdown-link-check) is
-used to check for broken links. Its configuration file for this repository is [`.markdown-link-check.json`](https://github.com/UBCSailbot/docs/blob/main/.markdown-link-check.json).
+2. [markdown-link-check](https://github.com/tcort/markdown-link-check){target=_blank} is
+used to check for broken links. Its configuration file for this repository is [`.markdown-link-check.json`](https://github.com/UBCSailbot/docs/blob/main/.markdown-link-check.json){target=_blank}.
 
 [^1]: <https://www.markdownguide.org/getting-started/>

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -5,12 +5,12 @@ This page addresses what conventions we use specifically when programming in Pyt
 
 ## Style guide
 
-To ensure that the codebase stays clean, we use [flake8](https://flake8.pycqa.org/en/5.0.4/#), which is a tool
-for style guide enforcement mostly based off [pep8](https://peps.python.org/pep-0008/). To automate most of this
-process, we use [autopep8](https://github.com/hhatto/autopep8), which is a tool that resolves most style issues.
-However, there will be some issues that must be resolved by you!
+To ensure that the codebase stays clean, we use [flake8](https://flake8.pycqa.org/en/5.0.4/#){target=_blank}, which is a
+tool for style guide enforcement mostly based off [pep8](https://peps.python.org/pep-0008/){target=_blank}. To automate
+most of this process, we use [autopep8](https://github.com/hhatto/autopep8){target=_blank}, which is a tool that resolves
+most style issues. However, there will be some issues that must be resolved by you!
 
-Refer to this [guide](https://realpython.com/python-pep8/) on how to write readable code in python with the
+Refer to this [guide](https://realpython.com/python-pep8/){target=_blank} on how to write readable code in python with the
 pep8 style guide.
 
 !!! note
@@ -38,7 +38,7 @@ self explanatory. It should be done only when absolutely necessary.
 
 ### Generating docstrings
 
-We use a vscode extension called [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring)
+We use a vscode extension called [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring){target=_blank}
 which autogenerates docstrings that we use to document our code. To install this extension, go to the `Extensions` tab in
 vscode and search `autoDocstring` in the marketplace.
 

--- a/docs/reference/python/index.md
+++ b/docs/reference/python/index.md
@@ -12,10 +12,10 @@ as you would with most technical skills!
 
 | Resource               | Description                                                                                 |
 | :--------------------- | :------------------------------------------------------------------------------------------ |
-| [The Python Tutorial](https://docs.python.org/3/tutorial/) | The official python tutorial. Good if you have some time on your hands and you are a completionist. Sections 1 - 5 and 9 are the most relevant. |
-| [w3schools Tutorial](https://www.w3schools.com/python/default.asp) | Good if you want a more brief introduction to Python. It breaks down a lot of concepts into sections. Everything up to Python Classes/Objects is relevant. |
-| [YouTube Tutorial](https://youtu.be/t8pPdKYpowI) | If you like video tutorials, then we recommend this tutorial. This video is about 5 hours long, but it pretty much covers everything that you'll need to know for Python and there are some hands on  projects. |
-| [Shorter YouTube Tutorial](https://youtu.be/kqtD5dpn9C8) | A shorter alternative YouTube tutorial condensed into 1 hour. It covers less material but still covers many of the essentials. |
-| [CodingBat Practice](https://codingbat.com/python) | Good resource to put your Python skills to practice on some simple coding problems. Note that this resource does not teach you python. |
+| [The Python Tutorial](https://docs.python.org/3/tutorial/){target=_blank} | The official python tutorial. Good if you have some time on your hands and you are a completionist. Sections 1 - 5 and 9 are the most relevant. |
+| [w3schools Tutorial](https://www.w3schools.com/python/default.asp){target=_blank} | Good if you want a more brief introduction to Python. It breaks down a lot of concepts into sections. Everything up to Python Classes/Objects is relevant. |
+| [YouTube Tutorial](https://youtu.be/t8pPdKYpowI){target=_blank} | If you like video tutorials, then we recommend this tutorial. This video is about 5 hours long, but it pretty much covers everything that you'll need to know for Python and there are some hands on  projects. |
+| [Shorter YouTube Tutorial](https://youtu.be/kqtD5dpn9C8){target=_blank} | A shorter alternative YouTube tutorial condensed into 1 hour. It covers less material but still covers many of the essentials. |
+| [CodingBat Practice](https://codingbat.com/python){target=_blank} | Good resource to put your Python skills to practice on some simple coding problems. Note that this resource does not teach you python. |
 
 Feel free to add other resources other than the ones listed above if you find any that you like!

--- a/docs/reference/python/virtual-environments.md
+++ b/docs/reference/python/virtual-environments.md
@@ -12,8 +12,8 @@ dependencies in a configuration file.
 
 - **Housekeeping:** Virtual environments allow you to keep your global workspace tidy.
 
-There are two main methods of creating virtual environments: [virtualenv](https://pypi.org/project/virtualenv/)
-and [Anaconda](https://www.anaconda.com/). Each have their own benefits and drawbacks. Here are some differences
+There are two main methods of creating virtual environments: [virtualenv](https://pypi.org/project/virtualenv/){target=_blank}
+and [Anaconda](https://www.anaconda.com/){target=_blank}. Each have their own benefits and drawbacks. Here are some differences
 between the two:
 
 | Virtualenv                                        | Anaconda                                                 |
@@ -38,8 +38,8 @@ We recommend **virtualenv** over Anaconda because of its simplicity. However, fe
 
 === ":simple-anaconda: Anaconda"
 
-    Go to the official [Anaconda website](https://www.anaconda.com/) and follow the installation instructions 
-    for your operating system.
+    Go to the official [Anaconda website](https://www.anaconda.com/){target=_blank} and follow the installation
+    instructions for your operating system.
 
 ## Using virtual environments
 
@@ -146,7 +146,7 @@ errors because they will not be found unless you install those dependencies in t
         ```
 
         Sometimes, installing a package like this simply won't work because you are not installing
-        from the correct [channel](https://conda.io/projects/conda/en/latest/user-guide/concepts/channels.html).
+        from the correct [channel](https://conda.io/projects/conda/en/latest/user-guide/concepts/channels.html){target=_blank}.
         You usually will have to google the command to use in order to install your package correctly because
         it usually comes from a specific channel that you don't know about. Some common channels to try are:
 
@@ -259,5 +259,5 @@ In this section, we summarized what virtual environments are, why they are used,
 cover all of the functions of virtual environments, but feel free to consult the official references to learn
 about virtual environments more in depth.
 
-- [Virtualenv Reference](https://docs.python.org/3/library/venv.html#module-venv)
-- [Anaconda Reference](https://conda.io/projects/conda/en/latest/user-guide/concepts/environments.html#)
+- [Virtualenv Reference](https://docs.python.org/3/library/venv.html#module-venv){target=_blank}
+- [Anaconda Reference](https://conda.io/projects/conda/en/latest/user-guide/concepts/environments.html#){target=_blank}

--- a/docs/reference/ros.md
+++ b/docs/reference/ros.md
@@ -8,21 +8,21 @@ We use ROS because it is open-source, language-agnostic, and built with cross-co
 It enables our subteams to work independently on well-defined components of our software system
 without having to worry about the hardware it runs on or the implementation of other components.
 
-[The official ROS 2 documentation](https://docs.ros.org/en/eloquent/index.html) contains everything you need
+[The official ROS 2 documentation](https://docs.ros.org/en/eloquent/index.html){target=_blank} contains everything you need
 to get started using ROS. From it we have hand-picked the resources that are most relevant to our current and expected
-future usage of ROS assuming that you use [our preconfigured workspace](https://github.com/UBCSailbot/sailbot_workspace).
-To run our software on your device without our workspace, you would have to [install ROS](https://docs.ros.org/en/eloquent/Installation.html)
-and the dependencies that are in [our Docker images](https://github.com/UBCSailbot/sailbot_workspace/tree/main/.devcontainer)
+future usage of ROS assuming that you use [our preconfigured workspace](https://github.com/UBCSailbot/sailbot_workspace){target=_blank}.
+To run our software on your device without our workspace, you would have to [install ROS](https://docs.ros.org/en/eloquent/Installation.html){target=_blank}
+and the dependencies that are in [our Docker images](https://github.com/UBCSailbot/sailbot_workspace/tree/main/.devcontainer){target=_blank}
 yourself.
 
 ## Workspace Configuration
 
 To get our workspace configuration running on your computer:
 
-1. Set it up by following the [setup instructions](https://github.com/UBCSailbot/sailbot_workspace#setup)
-2. Uncomment the ROS 2 tutorials section in [`.devcontainer/Dockerfile`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/.devcontainer/Dockerfile),
+1. Set it up by following the [setup instructions](https://github.com/UBCSailbot/sailbot_workspace#setup){target=_blank}
+2. Uncomment the ROS 2 tutorials section in [`.devcontainer/Dockerfile`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/.devcontainer/Dockerfile){target=_blank},
    then run the "Dev Containers: Rebuild Container" VS Code command, to install the tutorials' dependencies
-3. Uncomment the ROS 2 tutorials section in [`src/new_project.repos`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/src/new_project.repos),
+3. Uncomment the ROS 2 tutorials section in [`src/new_project.repos`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/src/new_project.repos){target=_blank},
    then run the "setup" VS Code task, to clone the repositories used in the tutorials
 
 Our workspace configuration contains easier methods of accomplishing some of the tutorial steps, or eliminates the need
@@ -43,7 +43,7 @@ We encourage all software members to work through the tutorials listed below in 
 For tutorials that have both C++ and Python versions, NET members should do the C++ version
 while CTRL and PATH members should do the Python version.
 
-[CLI Tools](https://docs.ros.org/en/eloquent/Tutorials.html#beginner-cli-tools)
+[CLI Tools](https://docs.ros.org/en/eloquent/Tutorials.html#beginner-cli-tools){target=_blank}
 
 - Introducing turtlesim and rqt
 - Understanding ROS 2 nodes
@@ -54,7 +54,7 @@ while CTRL and PATH members should do the Python version.
 - Using rqt_console
 - Recording and playing back data
 
-[Client Libraries](https://docs.ros.org/en/eloquent/Tutorials.html#beginner-client-libraries)
+[Client Libraries](https://docs.ros.org/en/eloquent/Tutorials.html#beginner-client-libraries){target=_blank}
 
 - Creating a workspace
 - Creating your first ROS 2 package
@@ -67,7 +67,7 @@ while CTRL and PATH members should do the Python version.
 
 We encourage all software members to read the following documentation on key ROS concepts:
 
-- [About logging and logger configuration](https://docs.ros.org/en/eloquent/Concepts/Logging.html)
+- [About logging and logger configuration](https://docs.ros.org/en/eloquent/Concepts/Logging.html){target=_blank}
 
 ## ROS 1 Bridge
 
@@ -75,14 +75,14 @@ There are two major versions of ROS, aptly named ROS 1 and ROS 2. Our previous p
 uses ROS 1 because it was the only version available during her design process. Our new project will
 use ROS 2, a complete re-design of the framework that tackles the shortcomings of ROS 1 to bring it up
 to industry needs and standards.[^3] If you are curious about the changes made in ROS 2 compared to 1,
-[this article](http://design.ros2.org/articles/changes.html) is a worthwhile read.
+[this article](http://design.ros2.org/articles/changes.html){target=_blank} is a worthwhile read.
 
 ROS 2 includes the ROS 1 Bridge, a collection of packages that can be installed alongside ROS 1 to help migrate code
 from ROS 1 to ROS 2. As we will be reusing parts of Raye's codebase, it is essential to know how to use these packages.
 Until we are completely done with Raye, our preconfigured workspace will have ROS 1, ROS 1 Bridge, and ROS 2 installed.
 
-We encourage all software members work through the [ROS 1 Bridge README](https://github.com/ros2/ros1_bridge/blob/master/README.md).
-For PATH members, the [Migrating launch files from ROS 1 to ROS 2 page](https://docs.ros.org/en/eloquent/Tutorials/Launch-files-migration-guide.html)
+We encourage all software members work through the [ROS 1 Bridge README](https://github.com/ros2/ros1_bridge/blob/master/README.md){target=_blank}.
+For PATH members, the [Migrating launch files from ROS 1 to ROS 2 page](https://docs.ros.org/en/eloquent/Tutorials/Launch-files-migration-guide.html){target=_blank}
 will be a helpful reference when we do so.
 
 [^1]: <https://docs.ros.org/en/humble/index.html>


### PR DESCRIPTION
Resolves #70

### What I Did
I created a GitHub Action that asserts that links to external sites redirect to a new tab using the regular expression defined in #70. Refer to [`./.github/actions/lint`](https://github.com/UBCSailbot/docs/tree/user/dfriend01/70-hyperlinks-action/.github/actions/lint) for the main logic behind the linter. Also check out the [latest run](https://github.com/UBCSailbot/docs/actions/runs/3353829300/jobs/5556927129) where the linter fails because of links that got matched by the regular expression.

### What to do once approved
1. Change all failing links so that linting passes
2. Remove line 7 in [`./.github/workflows/lint.yml`](https://github.com/UBCSailbot/docs/blob/user/dfriend01/70-hyperlinks-action/.github/workflows/lint.yml)
