### PR TITLE
Update Python Conventions Page with Python Hinting

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -16,6 +16,7 @@
         "ighxy",
         "iostream",
         "mkdocs",
+        "mypy",
         "Protobuf",
         "Raye",
         "srcnew",

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -5,6 +5,8 @@ This page addresses what conventions we use specifically when programming in Pyt
 
 ## Style guide
 
+### Linting
+
 To ensure that the codebase stays clean, we use [flake8](https://flake8.pycqa.org/en/5.0.4/#){target=_blank}, which is a
 tool for style guide enforcement mostly based off [pep8](https://peps.python.org/pep-0008/){target=_blank}. To automate
 most of this process, we use [autopep8](https://github.com/hhatto/autopep8){target=_blank}, which is a tool that resolves
@@ -25,9 +27,6 @@ errors, documents code, improves IDEs and linters, and helps build and maintain 
 Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}
 can be used.
 
-There are [pros and cons](https://realpython.com/lessons/pros-and-cons-type-hints/){target=_blank} to using type
-hinting, make sure that you are aware of them before deciding to utilize them in your codebase.
-
 There is some syntax to get familiar in order to use type checking. We recommend the following resources:
 
 - [mypy Typing Cheatsheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html){target=_blank}
@@ -36,7 +35,7 @@ There is some syntax to get familiar in order to use type checking. We recommend
 
 Below are a few examples of using type hinting:
 
-??? example "Return the sum of a sequence"
+???+ example "Return the sum of a sequence"
 
     ```python
     from typing import Sequence, Union
@@ -49,7 +48,7 @@ Below are a few examples of using type hinting:
         return sum(seq)
     ```
 
-??? example "Function with optional parameters and default values"
+???+ example "Function with optional parameters and default values"
 
     ```python
     from typing import Optional

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -36,6 +36,90 @@ and future members of the software team. The major things that we document in ou
 Ideally, the third point should be avoided as much as possible since we would want our code to be
 self explanatory. It should be done only when absolutely necessary.
 
+### Type hinting and static type checking
+
+Since Python is a dynamically typed language, we need to make use of the [`typing`](https://docs.python.org/3/library/typing.html){target=_blank}
+and [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank} modules if we want to do
+any type checking in our functions and classes. Type checking is beneficial for documentation and maintaining a clean
+software architecture. There is some syntax to get familiar in order to use type checking. We recommend the following
+resources:
+
+- [mypy Typing Cheatsheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html){target=_blank}
+- [PEP 483: The Theory of Type Hints (A Simplified Guide)](https://peps.python.org/pep-0483/){target=_blank}
+- [PEP 484: Type Hints (Fully Comprehensive Guide)](https://peps.python.org/pep-0484/){target=_blank}
+
+You can check for type mismatches in the command line by running `mypy myfile.py`. Below are a few examples of
+using type hinting:
+
+??? example "Return the sum of a sequence"
+
+    ```python
+    from typing import Sequence, Union
+    Number = Union[int, float]
+
+    def sumseq(seq : Sequence[Number]) -> Number:
+        return sum(seq)
+    ```
+
+??? example "Function with optional parameters and default values"
+
+    ```python
+    from typing import Optional
+
+    def printArgs(a : str, b : str="World", c : Optional[str]=None) -> None:
+        print(f"Value of a: {a}")
+        print(f"Value of b: {b}")
+        if c is not None:
+            print(f"Value of c: {c}")
+    ```
+
+??? example "Function with custom class"
+
+    ```python
+    class MyClass:
+        def __init__(self) -> None:
+            pass
+
+    def foo(a : MyClass) -> None:
+        print(a)
+    ```
+
+??? example "Forward referencing a class"
+
+    === "With `__future__`"
+
+        ```python
+        from __future__ import annotations
+
+        def foo(a : MyClass) -> None:
+            print(a)
+
+        class MyClass:
+            def __init__(self) -> None:
+                pass
+        ```
+
+    === "Without `__future__`"
+
+        ```python
+        def foo(a : 'MyClass') -> None:
+            print(a)
+
+        class MyClass:
+            def __init__(self) -> None:
+                pass
+        ```
+
+??? example "Function that never returns"
+
+    ```python
+    from typing import NoReturn
+
+    def bar() -> NoReturn:
+        while True:
+            print("Hello World!")
+    ```
+
 ### Generating docstrings
 
 We use a vscode extension called [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring){target=_blank}

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -36,12 +36,13 @@ and future members of the software team. The major things that we document in ou
 Ideally, the third point should be avoided as much as possible since we would want our code to be
 self explanatory. It should be done only when absolutely necessary.
 
-### Type hinting and static type checking
+### Type hinting
 
 Since Python is a dynamically typed language, we need to make use of the [`typing`](https://docs.python.org/3/library/typing.html){target=_blank}
 and [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank} modules if we want to do
 any type checking in our functions and classes. Type checking is beneficial for documentation and maintaining a clean
-software architecture. There is some syntax to get familiar in order to use type checking. We recommend the following
+software architecture while catching errors through static type checking using mypy, which is a static type checker.
+There is some syntax to get familiar in order to use type checking. We recommend the following
 resources:
 
 - [mypy Typing Cheatsheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html){target=_blank}
@@ -55,7 +56,10 @@ using type hinting:
 
     ```python
     from typing import Sequence, Union
+
+
     Number = Union[int, float]
+
 
     def sumseq(seq : Sequence[Number]) -> Number:
         return sum(seq)
@@ -65,6 +69,7 @@ using type hinting:
 
     ```python
     from typing import Optional
+
 
     def printArgs(a : str, b : str="World", c : Optional[str]=None) -> None:
         print(f"Value of a: {a}")
@@ -80,6 +85,7 @@ using type hinting:
         def __init__(self) -> None:
             pass
 
+
     def foo(a : MyClass) -> None:
         print(a)
     ```
@@ -91,8 +97,10 @@ using type hinting:
         ```python
         from __future__ import annotations
 
+
         def foo(a : MyClass) -> None:
             print(a)
+
 
         class MyClass:
             def __init__(self) -> None:
@@ -105,6 +113,7 @@ using type hinting:
         def foo(a : 'MyClass') -> None:
             print(a)
 
+
         class MyClass:
             def __init__(self) -> None:
                 pass
@@ -114,6 +123,7 @@ using type hinting:
 
     ```python
     from typing import NoReturn
+
 
     def bar() -> NoReturn:
         while True:

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -22,7 +22,8 @@ pep8 style guide.
 
 Even though Python is a dynamically typed language, newer versions support type hinting. Type hinting catches
 errors, documents code, improves IDEs and linters, and helps build and maintain a clean software architecture.[^1]
-Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}.
+Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}
+can be used.
 
 There are [pros and cons](https://realpython.com/lessons/pros-and-cons-type-hints/){target=_blank} to using type
 hinting, make sure that you are aware of them before deciding to utilize them in your codebase.

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -18,39 +18,18 @@ pep8 style guide.
     Our CI automatically checks that your code follows the pep8 standard. If it does not, your pull requests will
     be blocked from being merged until those issues are resolved!
 
-## Documentation
+## Type hinting
 
-Code is written once and read a thousand times, so it is important to provide good documentation for current
-and future members of the software team. The major things that we document in our code are:
-
-1. **Classes and Objects:**
-    - What does it represent? What is it used for?
-    - What are its member variables? What are they used for?
-2. **Functions:**
-    - What are the inputs and outputs?
-    - What is the overall behavior and purpose of the function?
-3. **Code:**
-    - Is a line of code obscure and/or not clear? Add an inline comment to clear things up.
-    - Break down a large process.
-
-Ideally, the third point should be avoided as much as possible since we would want our code to be
-self explanatory. It should be done only when absolutely necessary.
-
-### Type hinting
-
-Since Python is a dynamically typed language, we need to make use of the [`typing`](https://docs.python.org/3/library/typing.html){target=_blank}
-and [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank} modules if we want to do
-any type checking in our functions and classes. Type checking is beneficial for documentation and maintaining a clean
-software architecture while catching errors through static type checking using mypy, which is a static type checker.
-There is some syntax to get familiar in order to use type checking. We recommend the following
-resources:
+Even though Python is a dynamically typed language, newer versions support type hinting. Type hinting catches
+errors, documents code, improves IDEs and linters, and helps build and maintain a clean software architecture.[^1]
+Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}
+can be used. There is some syntax to get familiar in order to use type checking. We recommend the following resources:
 
 - [mypy Typing Cheatsheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html){target=_blank}
 - [PEP 483: The Theory of Type Hints (A Simplified Guide)](https://peps.python.org/pep-0483/){target=_blank}
 - [PEP 484: Type Hints (Fully Comprehensive Guide)](https://peps.python.org/pep-0484/){target=_blank}
 
-You can check for type mismatches in the command line by running `mypy myfile.py`. Below are a few examples of
-using type hinting:
+Below are a few examples of using type hinting:
 
 ??? example "Return the sum of a sequence"
 
@@ -129,6 +108,24 @@ using type hinting:
         while True:
             print("Hello World!")
     ```
+
+## Documentation
+
+Code is written once and read a thousand times, so it is important to provide good documentation for current
+and future members of the software team. The major things that we document in our code are:
+
+1. **Classes and Objects:**
+    - What does it represent? What is it used for?
+    - What are its member variables? What are they used for?
+2. **Functions:**
+    - What are the inputs and outputs?
+    - What is the overall behavior and purpose of the function?
+3. **Code:**
+    - Is a line of code obscure and/or not clear? Add an inline comment to clear things up.
+    - Break down a large process.
+
+Ideally, the third point should be avoided as much as possible since we would want our code to be
+self explanatory. It should be done only when absolutely necessary.
 
 ### Generating docstrings
 
@@ -236,3 +233,5 @@ autoDocstring extension.
             length = len(self.__stack)
             return length
     ```
+
+[^1]: <https://realpython.com/lessons/pros-and-cons-type-hints/>

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -42,6 +42,24 @@ Since Python is a dynamically typed language, we need to make use of the [`typin
 and [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank} modules if we want to do
 any type checking in our functions and classes. Type checking is beneficial for documentation and maintaining a clean
 software architecture while catching errors through static type checking using mypy, which is a static type checker.
+
+Although type hinting can be beneficial, there are also some takeaways which include:[^1]
+
+- **Takes more time and effort.** You will likely need to spend time learning how to use the `typing` module and `mypy`,
+and there will also be more time spent debugging type mismatches.
+- **Works best in newer Python versions.** You will likely have a better experience with type checking with Python 3.6
+or higher than older versions.
+- **There is a start-up time penalty.** Importing the `typing` module may cause noticeable delays for small scripts that
+are meant to be ran quickly.
+
+If you want to determine whether to use type hinting or not, these are some good rules of thumb:[^1]
+
+- Type hints do not add much to shorter scripts, and especially if they do not play a major role in a larger codebase.
+- Type hints are beneficial for others if you plan on making your project open source, and especially if published on
+[PyPI](https://realpython.com/pypi-publish-python-package/){target=_blank}.
+- Type hints are useful in larger projects because it can help you keep track of the types in complex workflows. This
+becomes even more apparent when you are collaborating with others on the same project.
+
 There is some syntax to get familiar in order to use type checking. We recommend the following
 resources:
 
@@ -236,3 +254,5 @@ autoDocstring extension.
             length = len(self.__stack)
             return length
     ```
+
+[^1]: <https://realpython.com/lessons/pros-and-cons-type-hints/>

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -134,7 +134,8 @@ which autogenerates docstrings that we use to document our code. To install this
 vscode and search `autoDocstring` in the marketplace.
 
 To generate docstrings, type `"""` at the beginning of the function that you want to document and the template
-will be generated for you! If you use type hinting, this extention will autofill some of the documentation for you!
+will be generated for you! If you use [type hinting](#type-hinting), this extention will autofill some of the
+documentation for you!
 
 !!! note
 

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -1,7 +1,8 @@
 # Conventions
 
 At UBC Sailbot, we follow standards in how we code to maintain a clean and comprehensible codebase.
-This page addresses what conventions we use specifically when programming in Python.
+This page addresses what conventions we use specifically when programming in Python and the tools to help us maintain
+these conventions.
 
 ## Style guide
 
@@ -151,7 +152,7 @@ documentation for you!
 It's hard to imagine what good documentation looks like. We provide a few examples below of documenting code using the
 autoDocstring extension.
 
-??? example "Documentation example on a function"
+???+ example "Documentation example on a function"
 
     ```python
     from typing import List

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -22,24 +22,10 @@ pep8 style guide.
 
 Even though Python is a dynamically typed language, newer versions support type hinting. Type hinting catches
 errors, documents code, improves IDEs and linters, and helps build and maintain a clean software architecture.[^1]
-Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}
+Expanding on how it catches errors, a static type checker such as [`mypy`](https://mypy.readthedocs.io/en/stable/index.html){target=_blank}.
 
-Although type hinting can be beneficial, there are also some takeaways which include:[^1]
-
-- **Takes more time and effort.** You will likely need to spend time learning how to use the `typing` module and `mypy`,
-and there will also be more time spent debugging type mismatches.
-- **Works best in newer Python versions.** You will likely have a better experience with type checking with Python 3.6
-or higher than older versions.
-- **There is a start-up time penalty.** Importing the `typing` module may cause noticeable delays for small scripts that
-are meant to be ran quickly.
-
-If you want to determine whether to use type hinting or not, these are some good rules of thumb:[^1]
-
-- Type hints do not add much to shorter scripts, and especially if they do not play a major role in a larger codebase.
-- Type hints are beneficial for others if you plan on making your project open source, and especially if published on
-[PyPI](https://realpython.com/pypi-publish-python-package/){target=_blank}.
-- Type hints are useful in larger projects because it can help you keep track of the types in complex workflows. This
-becomes even more apparent when you are collaborating with others on the same project.
+There are [pros and cons](https://realpython.com/lessons/pros-and-cons-type-hints/){target=_blank} to using type
+hinting, make sure that you are aware of them before deciding to utilize them in your codebase.
 
 There is some syntax to get familiar in order to use type checking. We recommend the following resources:
 

--- a/docs/reference/python/conventions.md
+++ b/docs/reference/python/conventions.md
@@ -43,7 +43,7 @@ which autogenerates docstrings that we use to document our code. To install this
 vscode and search `autoDocstring` in the marketplace.
 
 To generate docstrings, type `"""` at the beginning of the function that you want to document and the template
-will be generated for you!
+will be generated for you! If you use type hinting, this extention will autofill some of the documentation for you!
 
 !!! note
 
@@ -55,84 +55,90 @@ will be generated for you!
 It's hard to imagine what good documentation looks like. We provide a few examples below of documenting code using the
 autoDocstring extension.
 
-```python title="Documentation example on a function"
-def inner_product(v1, v2):
-    """
-    Computes the inner product between two 1D real vectors. Input vectors should have the
-    same dimensions.
+??? example "Documentation example on a function"
 
-    Args:
-        v1 (List[float]): The first vector of real numbers.
-        v2 (List[float]): The second vector of real numbers.
-
-    Returns:
-       float : The inner product between v1 and v2
-    """
-    assert (len(v1) == len(v2)), "Input lists must have same length"
-
-    # Iterate through elementwise pairs
-    summation = 0
-    for e1, e2 in zip(v1, v2):
-        summation += (e1 * e2)
-    return float(summation)
-```
-
-```python title="Documentation example with a stack"
-class Stack:
-
-    """
-    This class represents a stack, which is an abstract data type that serves as a collection of
-    elements. The stack is a LIFO datastructure defined by two main operations: Push and Pop.
-
-    Attributes:
-        __stack (List[Any]): A list containing the elements on the stack.
-    """
-
-    def __init__(self):
+    ```python
+    from typing import List
+    def inner_product(v1 : List[float], v2 : List[float]) -> float:
         """
-        Initializes the Stack object.
-        """
-        self.__stack = []
-
-    def push(self, element):
-        """
-        Pushes an element to the top of the stack.
+        Computes the inner product between two 1D real vectors. Input vectors should have the
+        same dimensions.
 
         Args:
-            element (Any): The element to be pushed on to the stack.
-        """
-        self.__stack.append(element)
-
-    def pop(self):
-        """
-        Removes the element at the top of the stack and returns it. If the stack is empty,
-        then None is returned.
+            v1 (List[float]): The first vector of real numbers.
+            v2 (List[float]): The second vector of real numbers.
 
         Returns:
-            Any, NoneType: The element at the top of the stack.
+        float : The inner product between v1 and v2
         """
-        if self.is_empty():
-            return None
-        else:
-            return self.__stack.pop()
+        assert (len(v1) == len(v2)), "Input lists must have same length"
 
-    def is_empty(self):
-        """
-        Determines whether the stack is empty or not.
+        # Iterate through elementwise pairs
+        summation = 0
+        for e1, e2 in zip(v1, v2):
+            summation += (e1 * e2)
+        return float(summation)
+    ```
 
-        Returns:
-            bool: Returns True if the stack is empty, and False otherwise.
-        """
-        empty = (len(self.__stack) == 0)
-        return empty
+??? example "Documentation example with a stack"
 
-    def __len__(self):
-        """
-        Gets the number of elements on the stack.
+    ```python
+    from typing import Any
+    class Stack:
 
-        Returns:
-            int: The number of elements on the stack.
         """
-        length = len(self.__stack)
-        return length
-```
+        This class represents a stack, which is an abstract data type that serves as a collection of
+        elements. The stack is a LIFO datastructure defined by two main operations: Push and Pop.
+
+        Attributes:
+            __stack (List[Any]): A list containing the elements on the stack.
+        """
+
+        def __init__(self):
+            """
+            Initializes the Stack object.
+            """
+            self.__stack = []
+
+        def push(self, element : Any) -> Any:
+            """
+            Pushes an element to the top of the stack.
+
+            Args:
+                element (Any): The element to be pushed on to the stack.
+            """
+            self.__stack.append(element)
+
+        def pop(self) -> Any:
+            """
+            Removes the element at the top of the stack and returns it. If the stack is empty,
+            then None is returned.
+
+            Returns:
+                Any, NoneType: The element at the top of the stack.
+            """
+            if self.is_empty():
+                return None
+            else:
+                return self.__stack.pop()
+
+        def is_empty(self) -> bool:
+            """
+            Determines whether the stack is empty or not.
+
+            Returns:
+                bool: Returns True if the stack is empty, and False otherwise.
+            """
+            empty = (len(self.__stack) == 0)
+            return empty
+
+        def __len__(self) -> int:
+            """
+            Gets the number of elements on the stack.
+
+            Returns:
+                int: The number of elements on the stack.
+            """
+            length = len(self.__stack)
+            return length
+    ```

--- a/docs/reference/python/index.md
+++ b/docs/reference/python/index.md
@@ -6,7 +6,7 @@ so it is critical that you are familiar with the language if you are on one of t
 ## Python tutorials
 
 We understand that not everyone who joins Sailbot has Python in their toolkit, nor do we expect it either! Whether you
-are learning Python for the first time or you just want to brush up, we have provided some resources below. You **will not**
+are learning Python for the first time or you just want to brush up, we have provided some resources below. You may not
 learn absolutely everything from the resources below, but it is a good starting point. You will mostly learn through doing,
 as you would with most technical skills!
 

--- a/docs/reference/python/virtual-environments.md
+++ b/docs/reference/python/virtual-environments.md
@@ -19,7 +19,7 @@ between the two:
 | Virtualenv                                        | Anaconda                                                 |
 | :------------------------------------------------ | :------------------------------------------------------- |
 | Environment files are local.                      | Environment files are available globally.                |
-| Must activate environment by giving the path.     | Can activate the environment without knowing the path.   |
+| Must activate environment by giving the path.     | Can activate the environment without knowing the path, but only the name. |
 | Can only use `pip` to install packages.           | Can either use `pip` or built-in `conda` package manager.|
 | Installation is very simple.                      | Installation takes more effort.                          |
 | Can only install python packages.                 | In addition to packages, you can download many data science tools.|


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #102
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Added type hinting section in the Python Conventions section.

We should check that type hinting is worth holding as a standard, as the syntax takes some effort to get used to. However, the benefit is that `mypy` allows us to incrementally add type hinting to our code, so our code will not break even if everything does not have type hinting. This would more be for documentation and linting purposes.
