### PR TITLE
Render only trailing whitespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
             "strings": "off"
         },
         "editor.rulers": [120],
-        "editor.renderWhitespace": "all",
+        "editor.renderWhitespace": "trailing",
         "cSpell.fixSpellingWithRenameProvider": true,
         "cSpell.advanced.feature.useReferenceProviderWithRename": true,
         "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Before this PR VS Code rendered all whitespace. This is not necessary, but it is helpful to see trailing whitespace as this is a markdownlint error

