### PR TITLE
Correct conda default python version

### DIFF
--- a/docs/reference/python/virtual-environments.md
+++ b/docs/reference/python/virtual-environments.md
@@ -74,8 +74,8 @@ name unless specified otherwise.
     conda env create -n env python=<PYTHON VERSION NUM>
     ```
 
-    If you don't specify a python version, the default is the version you used when you downloaded and installed Anaconda. Verify that your environment is created
-    by executing `conda env list`.
+    If you don't specify a python version, the default is the version you used when you downloaded and installed Anaconda.
+    Verify that your environment is created by executing `conda env list`.
 
 ### Activating the virtual environment
 

--- a/docs/reference/python/virtual-environments.md
+++ b/docs/reference/python/virtual-environments.md
@@ -74,7 +74,7 @@ name unless specified otherwise.
     conda env create -n env python=<PYTHON VERSION NUM>
     ```
 
-    If you don't specify a python version, the default is the latest version. Verify that your environment is created
+    If you don't specify a python version, the default is the version you used when you downloaded and installed Anaconda. Verify that your environment is created
     by executing `conda env list`.
 
 ### Activating the virtual environment


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Default Python version for conda is the version used to download and install Anaconda: https://conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-python