### PR TITLE
Stop cancelling in progress jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,6 @@ on:
     - cron: '0 11 * * 6'
   workflow_dispatch:
 
-# Cancel in-progress runs for the current workflow
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   # CI for all UBCSailbot repositories defined in one place
   # Runs another workflow: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow


### PR DESCRIPTION
I noticed that some jobs are being cancelled that aren't supposed to be because of our `concurrency` field: https://github.com/UBCSailbot/docs/actions/runs/6233402151 (I reran it manually afterwards). This causes the docs site to not be updated correctly. Rather than try to fix the group, I removed it altogether because CI doesn't take long anyways.